### PR TITLE
DigitalNote v1.0.1.2 Release

### DIFF
--- a/DigitalNote.pro
+++ b/DigitalNote.pro
@@ -1,6 +1,6 @@
 TEMPLATE = app
 TARGET = DigitalNote-qt
-VERSION = 1.0.1.1
+VERSION = 1.0.1.2
 INCLUDEPATH += src src/json src/qt src/qt/plugins/mrichtexteditor
 QT += core gui widgets network printsupport
 DEFINES += ENABLE_WALLET

--- a/src/blockparams.cpp
+++ b/src/blockparams.cpp
@@ -316,11 +316,11 @@ unsigned int VRX_Retarget(const CBlockIndex* pindexLast, bool fProofOfStake)
         return bnVelocity.GetCompact(); // can't index prevblock
 
     // Live fork toggle diff reset
-    if(nLiveForkToggle > 0)
+    if(pindexLast->GetBlockTime() > 0)
     {
-        if(pindexLast->nHeight > nLiveForkToggle) // Selectable toggle
+        if(pindexLast->GetBlockTime() > nPaymentUpdate_1) // Monday, May 20, 2019 12:00:00 AM
         {
-            if(pindexLast->nHeight < nLiveForkToggle+5) {
+            if(pindexLast->GetBlockTime() < nPaymentUpdate_1+480) {
                 return bnVelocity.GetCompact(); // diff reset
             }
         }
@@ -541,9 +541,9 @@ int64_t GetMasternodePayment(int nHeight, int64_t blockValue)
     // Set calculated position of seesaw arc
     retDouble = swingSubsidy * seesawBase;
     // v1.1 payment subsidy patch
-    if(nLiveForkToggle > 0)
+    if(pindexBest->GetBlockTime() > 0)
     {
-        if(pindexBest->nHeight > nLiveForkToggle) // Selectable toggle
+        if(pindexBest->GetBlockTime() > nPaymentUpdate_1) // Monday, May 20, 2019 12:00:00 AM
         {
             // set returned value to calculated value
             ret = retDouble;

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -9,7 +9,7 @@
 #define CLIENT_VERSION_MAJOR       1
 #define CLIENT_VERSION_MINOR       0
 #define CLIENT_VERSION_REVISION    1
-#define CLIENT_VERSION_BUILD       1
+#define CLIENT_VERSION_BUILD       2
 
 // Set to true for release, false for prerelease or test build
 #define CLIENT_VERSION_IS_RELEASE  true

--- a/src/fork.h
+++ b/src/fork.h
@@ -10,6 +10,8 @@
 
 /** Reserve Phase start block */ 
 static const int64_t nReservePhaseStart = 1;
+/** Masternode/Devops Payment Update 1 **/
+static const int64_t nPaymentUpdate_1 = 1558310400;
 /** Velocity toggle block */
 static const int64_t VELOCITY_TOGGLE = 175; // Implementation of the Velocity system into the chain.
 /** Velocity retarget toggle block */

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -371,9 +371,9 @@ CBlock* CreateNewBlock(CReserveKey& reservekey, bool fProofOfStake, int64_t* pFe
         if (!fProofOfStake){
             pblock->vtx[0].vout[0].nValue = GetProofOfWorkReward(pindexPrev->nHeight + 1, nFees);
 
-            // TODO: Verify upgrade
-            if(nLiveForkToggle > 0){
-                if(pindexPrev->nHeight + 1 > nLiveForkToggle){
+            // Check for payment update fork
+            if(pindexBest->GetBlockTime() > 0){
+                if(pindexBest->GetBlockTime() > nPaymentUpdate_1){ // Monday, May 20, 2019 12:00:00 AM
                     // masternode/devops payment
                     int64_t blockReward = GetProofOfWorkReward(pindexPrev->nHeight + 1, nFees);
                     bool hasPayment = true;

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -675,9 +675,9 @@ Value getblocktemplate(const Array& params, bool fHelp)
     result.push_back(Pair("votes", aVotes));
 
     // TODO: Verify upgrade
-    if (nLiveForkToggle > 0)
+    if (pindexBest->GetBlockTime() > 0)
     {
-        if (pindexBest->nHeight > nLiveForkToggle)
+        if (pindexBest->GetBlockTime() > nPaymentUpdate_1) // Monday, May 20, 2019 12:00:00 AM
         {
             // Set Masternode / DevOps payments
             int64_t masternodePayment = GetMasternodePayment(pindexPrev->nHeight+1, (int64_t)pblock->vtx[0].vout[0].nValue);

--- a/src/version.h
+++ b/src/version.h
@@ -30,23 +30,23 @@ static const int DATABASE_VERSION = 70509;
 //
 // network protocol versioning
 //
-static const int PROTOCOL_VERSION = 62008;
+static const int PROTOCOL_VERSION = 62009;
 
 // intial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
 
 // disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 62005;
+static const int MIN_PEER_PROTO_VERSION = 62007;
 
 // minimum peer version accepted by MNenginePool
-static const int MIN_POOL_PEER_PROTO_VERSION = 62005;
-static const int MIN_INSTANTX_PROTO_VERSION = 62005;
+static const int MIN_POOL_PEER_PROTO_VERSION = 62007;
+static const int MIN_INSTANTX_PROTO_VERSION = 62007;
 
 //! minimum peer version that can receive masternode payments
 // V1 - Last protocol version before update
 // V2 - Newest protocol version
-static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_1 = 62005;
-static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2 = 62005;
+static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_1 = 62007;
+static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2 = 62007;
 
 // nTime field added to CAddress, starting with this version;
 // if possible, avoid requesting addresses nodes older than this
@@ -54,7 +54,13 @@ static const int CADDR_TIME_VERSION = 31402;
 
 // only request blocks from nodes outside this range of versions
 static const int NOBLKS_VERSION_START = 0;
-static const int NOBLKS_VERSION_END = 62004;
+static const int NOBLKS_VERSION_END = 62006;
+
+// hard cutoff time for legacy network connections
+static const int64_t HRD_LEGACY_CUTOFF = 1558310400; // ON (Monday, May 20, 2019 12:00:00 AM)
+
+// hard cutoff time for future network connections
+static const int64_t HRD_FUTURE_CUTOFF = 9993058800; // OFF (NOT TOGGLED)
 
 // BIP 0031, pong message, is enabled for all versions AFTER this one
 static const int BIP0031_VERSION = 60000;


### PR DESCRIPTION
Changelog

- Masternode payments corrected
- Devops and Masternode payments pay for BOTH PoW and PoS now
- Devops and Masternode payments and recipients are now verified via in-depth block checks
- Version bump for new update and upcoming fork
- Added live fork toggle for testing future prototype features like this one was tested
- Added network legacy cutoff toggled for fork date
- Added a devops fallback for a worst case scenerio of no masternodes on the network, chain will not be affected

NOTE: YOU MUST UPDATE BEFORE MAY 20TH 2019 !!!