### PR TITLE
DigitalNote v1.0.1.6 Release

### DIFF
--- a/DigitalNote.pro
+++ b/DigitalNote.pro
@@ -1,6 +1,6 @@
 TEMPLATE = app
 TARGET = DigitalNote-qt
-VERSION = 1.0.1.5
+VERSION = 1.0.1.6
 INCLUDEPATH += src src/json src/qt src/qt/plugins/mrichtexteditor
 QT += core gui widgets network printsupport
 DEFINES += ENABLE_WALLET

--- a/src/blockparams.cpp
+++ b/src/blockparams.cpp
@@ -308,7 +308,7 @@ void VRX_ThreadCurve(const CBlockIndex* pindexLast, bool fProofOfStake)
         if(fDebug) VRXswngdebug();
 
         // Version 1.2 Extended Curve Run Upgrade
-        if(pindexLast->GetBlockTime() > nPaymentUpdate_2) {// ON Monday, Jun 24, 2019 12:00:00 PM PDT
+        if(pindexLast->GetBlockTime() > nPaymentUpdate_2) {// ON Tuesday, Jul 02, 2019 12:00:00 PM PDT
             // Set unbiased comparison
             difTime = blkTime - cntTime;
             // Run Curve
@@ -355,7 +355,7 @@ void VRX_Dry_Run(const CBlockIndex* pindexLast)
                 return; // diff reset
             }
         }
-        if(pindexLast->GetBlockTime() > nPaymentUpdate_2) // ON Monday, Jun 24, 2019 12:00:00 PM PDT
+        if(pindexLast->GetBlockTime() > nPaymentUpdate_2) // ON Tuesday, Jul 02, 2019 12:00:00 PM PDT
         {
             if(pindexLast->GetBlockTime() < nPaymentUpdate_2+480) {
                 fDryRun = true;

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -9,7 +9,7 @@
 #define CLIENT_VERSION_MAJOR       1
 #define CLIENT_VERSION_MINOR       0
 #define CLIENT_VERSION_REVISION    1
-#define CLIENT_VERSION_BUILD       5
+#define CLIENT_VERSION_BUILD       6
 
 // Set to true for release, false for prerelease or test build
 #define CLIENT_VERSION_IS_RELEASE  true

--- a/src/fork.h
+++ b/src/fork.h
@@ -13,7 +13,7 @@ static const int64_t nReservePhaseStart = 1;
 /** Masternode/Devops Payment Update 1 **/
 static const int64_t nPaymentUpdate_1 = 1558310400;
 /** Masternode/Devops Payment Update 2 **/
-static const int64_t nPaymentUpdate_2 = 1561402800;
+static const int64_t nPaymentUpdate_2 = 1562094000;
 /** Velocity toggle block */
 static const int64_t VELOCITY_TOGGLE = 175; // Implementation of the Velocity system into the chain.
 /** Velocity retarget toggle block */

--- a/src/version.h
+++ b/src/version.h
@@ -30,7 +30,7 @@ static const int DATABASE_VERSION = 70509;
 //
 // network protocol versioning
 //
-static const int PROTOCOL_VERSION = 62012;
+static const int PROTOCOL_VERSION = 62013;
 
 // intial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -57,7 +57,7 @@ static const int NOBLKS_VERSION_START = 0;
 static const int NOBLKS_VERSION_END = 62008;
 
 // hard cutoff time for legacy network connections
-static const int64_t HRD_LEGACY_CUTOFF = 1561402800; // ON (Monday, Jun 24, 2019 12:00:00 PM PDT)
+static const int64_t HRD_LEGACY_CUTOFF = 1562094000; // ON (Tuesday, Jul 02, 2019 12:00:00 PM PDT)
 
 // hard cutoff time for future network connections
 static const int64_t HRD_FUTURE_CUTOFF = 9993058800; // OFF (NOT TOGGLED)


### PR DESCRIPTION
Changelog

- All previous upgrades from unreleased v1.0.1.5
- Version bump
- Mandatory update cutoff bump

THIS IS A MANDATORY UPDATE!!!
(As of Monday, July 02, 2019 12:00:00 PM GMT-07:00 all previous versions will become obsolete and no longer connect with the mainnet)