### PR TITLE
DigitalNote v1.0.1.9 Initial

### DIFF
--- a/DigitalNote.pro
+++ b/DigitalNote.pro
@@ -1,6 +1,6 @@
 TEMPLATE = app
 TARGET = DigitalNote-qt
-VERSION = 1.0.1.8
+VERSION = 1.0.1.9
 INCLUDEPATH += src src/json src/qt src/qt/plugins/mrichtexteditor
 QT += core gui widgets network printsupport
 DEFINES += ENABLE_WALLET

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -9,7 +9,7 @@
 #define CLIENT_VERSION_MAJOR       1
 #define CLIENT_VERSION_MINOR       0
 #define CLIENT_VERSION_REVISION    1
-#define CLIENT_VERSION_BUILD       8
+#define CLIENT_VERSION_BUILD       9
 
 // Set to true for release, false for prerelease or test build
 #define CLIENT_VERSION_IS_RELEASE  true

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2629,7 +2629,7 @@ bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, bool fCheckSig) c
         int64_t nDevopsPayment = 0;
         int64_t nProofOfIndexMasternode = 0;
         int64_t nProofOfIndexDevops = 0;
-        int64_t nMasterNodeChecksDelay = 30 * 60;
+        int64_t nMasterNodeChecksDelay = 45 * 60;
         int64_t nMasterNodeChecksEngageTime = 0;
         const CBlockIndex* pindexPrev = pindexBest->pprev;
         bool isProofOfStake = !IsProofOfWork();

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1289,13 +1289,13 @@ void ThreadSocketHandler()
                     pnode->fDisconnect = true;
                     pnode->CloseSocketDisconnect();
                 }
-                // Ping timeout
-                else if (pnode->nPingNonceSent && pnode->nPingUsecStart + TIMEOUT_INTERVAL * 1000000 < GetTimeMicros())
+                // Ping timeout - TODO Investigate this section and correct cause of Log spam during disconnect
+                /*else if (pnode->nPingNonceSent && pnode->nPingUsecStart + TIMEOUT_INTERVAL * 1000000 < GetTimeMicros())
                 {
                     LogPrintf("ping timeout: %fs\n", 0.000001 * (GetTimeMicros() - pnode->nPingUsecStart));
                     pnode->fDisconnect = true;
                     pnode->CloseSocketDisconnect();
-                }
+                }*/
             }
         }
         {

--- a/src/version.h
+++ b/src/version.h
@@ -30,7 +30,7 @@ static const int DATABASE_VERSION = 70509;
 //
 // network protocol versioning
 //
-static const int PROTOCOL_VERSION = 62015;
+static const int PROTOCOL_VERSION = 62016;
 
 // intial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
Changelog
------------

- Version bump
- Disabled problematic, non-essential network ping check (cause of debug log bloat, was added in 1.0.1.5)
- Bump in time buffer for check enforcement of MN addresses to allow proper connection to entire network preior to engagement

Note: Ping check will be re-enabled in 1.0.2.0