### PR TITLE
Fix build with openssl-1.1

### DIFF
--- a/src/secp256k1/build-aux/m4/bitcoin_secp.m4
+++ b/src/secp256k1/build-aux/m4/bitcoin_secp.m4
@@ -46,6 +46,10 @@ if test x"$has_libcrypto" = x"yes" && test x"$has_openssl_ec" = x; then
     ECDSA_sign(0, NULL, 0, NULL, NULL, eckey);
     ECDSA_verify(0, NULL, 0, NULL, 0, eckey);
     EC_KEY_free(eckey);
+    ECDSA_SIG *sig_openssl;
+    sig_openssl = ECDSA_SIG_new();
+    (void)sig_openssl->r;
+    ECDSA_SIG_free(sig_openssl);
   ]])],[has_openssl_ec=yes],[has_openssl_ec=no])
   AC_MSG_RESULT([$has_openssl_ec])
 fi


### PR DESCRIPTION
Hello.

This patch is taken from https://github.com/bitcoin-core/secp256k1/pull/433. Without it digitalnoted won't build with openssl-1.1 or newer.

Or alternatively maybe you can take fresh secp256k1 from Mar 31 2019 which is used in the recent bitcoin release?